### PR TITLE
We need to be able to send messages on FIFO type SQS queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# ViM related
+.vimproject
+*.swp
+*.AppleDouble
+*.sublime-project
+*.sublime-workspace
+.smbdelete*
+.DS_Store
+/.buildpath
+/.project
+
+# dev extensions
+.project
+.settings
+.idea
+.idea/*
+.vscode/**/*
+.phpintel/


### PR DESCRIPTION
We need to be able to send messages on FIFO type SQS queues
-- 

We need to send the `MessageGroupId` to be able to use the FIFO type SQS queues, otherwise the request is gonna fail. 

#### MessageGroupId ([Ref](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html))

> 
> This parameter applies only to FIFO (first-in-first-out) queues.
> 
> The tag that specifies that a message belongs to a specific message group. Messages that belong to the same message group are processed in a FIFO manner (however, messages in different message groups might be processed out of order). To interleave multiple ordered streams within a single queue, use MessageGroupId values (for example, session data for multiple users). In this scenario, multiple consumers can process the queue, but the session data of each user is processed in a FIFO fashion.
> 
> You must associate a non-empty MessageGroupId with a message. If you don't provide a MessageGroupId, the action fails.
> 
> ReceiveMessage might return messages with multiple MessageGroupId values. For each MessageGroupId, the messages are sorted by time sent. The caller can't specify a MessageGroupId.
> 
> The length of MessageGroupId is 128 characters. Valid values: alphanumeric characters and punctuation (!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~).
> 
> For best practices of using MessageGroupId, see Using the MessageGroupId Property in the Amazon Simple Queue Service Developer Guide.
> 
> Important
> 
> MessageGroupId is required for FIFO queues. You can't use it for Standard queues.
> 
> Type: String
> 
> Required: No

### PPH Scenario
Via running the following command on Staging I forcibly make the Event to use the new FIFO SQS queue: ([REF](https://github.com/PeoplePerHour/PPH-Yii/pull/39890/files))
```bash
yiic A*******e T*******ing --memid=1
```
but the request was failing due to the lack of the `MessageGroupId` attribute.

![failed_request](https://user-images.githubusercontent.com/9498242/63584150-096e2580-c5a5-11e9-9557-ec4d07398a98.png)

I patched the `AWSQueueManager` on a Staging PPH pod and retried.

#### The request succeeded 
I was able to see that the new items have been placed on the right queue
![send](https://user-images.githubusercontent.com/9498242/63584243-315d8900-c5a5-11e9-8a8b-1ade84f1477a.png)

#### Before process the queue
![before](https://user-images.githubusercontent.com/9498242/63584241-315d8900-c5a5-11e9-8c0d-7835354909d1.png)

#### [After process the queue ](https://github.com/PeoplePerHour/PPH-Yii/pull/39890/files#diff-483d202cdf068923465d2ffcab40bd25R100)
![processed](https://user-images.githubusercontent.com/9498242/63584239-30c4f280-c5a5-11e9-8897-2bdb5f02b432.png)




